### PR TITLE
No more ssh in lingo/.gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cppformat"]
 	path = cppformat
-	url = git@github.com:cppformat/cppformat.git
+	url = https://github.com/cppformat/cppformat.git


### PR DESCRIPTION
Remove use of ssh and switch to http so forks can update without headaches
